### PR TITLE
ci: add gh action with tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: "18.x"
+    - run: pnpm install
+    - run: pnpm build
+    - run: pnpm test


### PR DESCRIPTION
adds a github action that runs on pull requests/push. currently just runs the tests